### PR TITLE
Use standalone version of coursier

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Martynas Mickevičius <self at 2m dot lt>
-_version=1.1.0_M7
+_version=1.1.0-M8
 
 pkgname=coursier
-pkgver="$_version"
+pkgver="${_version/-/_}"
 pkgrel=1
 pkgdesc="Pure Scala Artifact Fetching"
 arch=('any')
@@ -10,10 +10,26 @@ url="http://get-coursier.io"
 license=('Apache')
 depends=('java-runtime-headless>=8' 'bash')
 
-source=("https://github.com/coursier/coursier/raw/v${pkgver/_/-}/coursier")
-sha256sums=('7ffb17aff47f17f663c35250d880c2d5db908ceae99dae05eb57bb6426f44539')
+source=("https://github.com/coursier/coursier/raw/v${_version}/coursier")
+sha256sums=('6c7be5eaab67a80fcb40473633650aa982360e94ee1834666b11c2f052612545')
 noextract=('coursier')
 
+build() {
+  cd "${srcdir}"
+  mkdir -p cache bin
+  export COURSIER_CACHE="${srcdir}/cache"
+  sh ./coursier bootstrap \
+    --intransitive "io.get-coursier::coursier-cli:${_version}" \
+    --classifier standalone \
+    -A jar \
+    -J "-noverify" \
+    --no-default \
+    -r central \
+    -r sonatype:releases \
+    -f -o "bin/coursier" \
+    -s
+}
+
 package() {
-  install -D -m755 "coursier" "${pkgdir}/usr/bin/coursier"
+  install -D -m755 "${srcdir}/bin/coursier" "${pkgdir}/usr/bin/coursier"
 }


### PR DESCRIPTION
See https://github.com/coursier/coursier/blob/master/scripts/generate-launcher.sh

see also the [FAQ](https://coursier.github.io/coursier/1.1.0-SNAPSHOT/docs/faq.html#on-first-launch-the-coursier-launcher-downloads-a-15-mb-jar-is-it-possible-to-have-a-standalone-launcher-that-would-not-need-to-download-things-on-first-launch)