### PR TITLE
Update 2.0.16 to 2.1.0-M1

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,14 +1,14 @@
 pkgbase = coursier
 	pkgdesc = Pure Scala Artifact Fetching
-	pkgver = 2.0.16
+	pkgver = 2.1.0_M1
 	pkgrel = 1
 	url = http://get-coursier.io
 	arch = any
 	license = Apache
 	depends = java-runtime-headless>=8
 	depends = bash
-	noextract = builder-2.0.16
-	source = builder-2.0.16::https://github.com/coursier/coursier/releases/download/v2.0.16/coursier
-	sha256sums = 631e8fbc1a3beb71a7130539b3b01852cfbe02edb94c5e9c6785981a0aee1e9c
+	noextract = builder-2.1.0_M1
+	source = builder-2.1.0_M1::https://github.com/coursier/coursier/releases/download/v2.1.0-M1/coursier
+	sha256sums = 25ea96cc09124aa85d6e092c7b5b920379386eea5ea56bafc7a194b417e875c8
 
 pkgname = coursier

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,5 +1,5 @@
 # Maintainer: Martynas Mickevičius <self at 2m dot lt>
-_version=2.0.16
+_version=2.1.0-M1
 
 pkgname=coursier
 pkgver="${_version//-/_}"
@@ -11,7 +11,7 @@ license=('Apache')
 depends=('java-runtime-headless>=8' 'bash')
 
 source=("builder-$pkgver::https://github.com/coursier/coursier/releases/download/v${_version}/coursier")
-sha256sums=('631e8fbc1a3beb71a7130539b3b01852cfbe02edb94c5e9c6785981a0aee1e9c')
+sha256sums=('25ea96cc09124aa85d6e092c7b5b920379386eea5ea56bafc7a194b417e875c8')
 noextract=("builder-$pkgver")
 
 build() {
@@ -31,4 +31,3 @@ build() {
 package() {
   install -D -m755 "${srcdir}/bin/coursier" "${pkgdir}/usr/bin/coursier"
 }
-


### PR DESCRIPTION
> https://github.com/coursier/coursier/releases/tag/v2.1.0-M1

The release of `v2.1.0_M1` is tagged with `Latest` and **not** tagged with `Pre-release` in GitHub.

Something I'm unsure of, should milestone version like `M1` be considered stable release?

From https://github.com/coursier/coursier/pull/1799, seems like even `coursier` itself doesn't consider so.

@2m If you think this is the case as well, feel free to close this PR. Thanks!