### PR TITLE
Update to 2.1.10

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,14 +1,14 @@
 pkgbase = coursier
 	pkgdesc = Pure Scala Artifact Fetching
-	pkgver = 2.1.9
+	pkgver = 2.1.10
 	pkgrel = 1
 	url = http://get-coursier.io
 	arch = any
 	license = Apache
 	depends = java-runtime-headless>=8
 	depends = bash
-	noextract = builder-2.1.9
-	source = builder-2.1.9::https://github.com/coursier/coursier/releases/download/v2.1.9/coursier
-	sha256sums = 663d270c2a5b4fb7e819d524c4f1bf15e963663d5a964fe0bc4d26fd3e169571
+	noextract = builder-2.1.10
+	source = builder-2.1.10::https://github.com/coursier/coursier/releases/download/v2.1.10/coursier
+	sha256sums = 7e26709830ee69a7c16d841d3b13e94eb95e30b3926a40ad7a2ce92b07064ad9
 
 pkgname = coursier

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,5 +1,5 @@
 # Maintainer: Martynas Mickevičius <self at 2m dot lt>
-_version=2.1.9
+_version=2.1.10
 
 pkgname=coursier
 pkgver="${_version//-/_}"
@@ -11,7 +11,7 @@ license=('Apache')
 depends=('java-runtime-headless>=8' 'bash')
 
 source=("builder-$pkgver::https://github.com/coursier/coursier/releases/download/v${_version}/coursier")
-sha256sums=('663d270c2a5b4fb7e819d524c4f1bf15e963663d5a964fe0bc4d26fd3e169571')
+sha256sums=('7e26709830ee69a7c16d841d3b13e94eb95e30b3926a40ad7a2ce92b07064ad9')
 noextract=("builder-$pkgver")
 
 build() {

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -20,7 +20,6 @@ build() {
   export COURSIER_CACHE="${srcdir}/cache"
   sh ./builder-$pkgver bootstrap \
     "io.get-coursier::coursier-cli:${_version}" \
-    --java-opt "-noverify" \
     --no-default \
     -r central \
     -r typesafe:ivy-releases \


### PR DESCRIPTION
Also removed Java `-noverify` option as it causes a deprecation warning to show up each time `coursier` is run, when using Java >= 13. Tested build and running with Java 8, 11, and 22, works for all without issue.